### PR TITLE
Add support for fractions to plural()

### DIFF
--- a/inform/inform.py
+++ b/inform/inform.py
@@ -1953,7 +1953,7 @@ class Inform:
             Command used to run the notifier. The command will be called with
             two arguments, the header and the body of the message.
 
-        \**kwargs:
+        \\**kwargs:
             Any additional keyword arguments are made attributes that are
             ignored by *Inform*, but may be accessed by the informants.
     """
@@ -2777,7 +2777,7 @@ class Error(Exception):
         The :func:`inform.error` function is called with the exception arguments.
 
         Args:
-            \**kwargs:
+            \\**kwargs:
                 *report()* takes any of the normal keyword arguments normally
                 allowed on an informant (culprit, template, etc.). Any keyword
                 argument specified here overrides those that were specified when
@@ -2797,7 +2797,7 @@ class Error(Exception):
         The :func:`inform.fatal` function is called with the exception arguments.
 
         Args:
-            \**kwargs:
+            \\**kwargs:
                 *report()* takes any of the normal keyword arguments normally
                 allowed on an informant (culprit, template, etc.). Any keyword
                 argument specified here overrides those that were specified when

--- a/inform/inform.py
+++ b/inform/inform.py
@@ -1111,20 +1111,25 @@ class plural:
             from collections import Sized
 
         x = self.value
-        number = len(x) if isinstance(x, Sized) else self.value
+        number = len(x) if isinstance(x, Sized) else x
+
         if formatter[0:1] == self.invert:
             formatter = formatter[1:]
-            use_singular = number != 1
+            use_singular = (number != 1)
         else:
-            use_singular = number == 1
-        formatter = formatter.replace(self.symbol, str(number))
+            use_singular = (number == 1)
+
         always, _, suffixes = formatter.partition(self.slash)
         if suffixes:
             singular, _, plural = suffixes.rpartition(self.slash)
         else:
             singular, plural = '', 's'
 
-        return "{}{}".format(always, singular if use_singular else plural)
+        # Don't replace the symbol until the very end, because it's possible 
+        # that this step could introduce extra separators (e.g. if the number 
+        # is a fraction).
+        out = always + (singular if use_singular else plural)
+        return out.replace(self.symbol, str(number))
 
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -665,6 +665,15 @@ def test_plural():
     assert '{:~@ cart|s}'.format(plural(2, invert='~', num='@', slash='|')) == '2 cart'
     assert plural(2, invert='~', num='@', slash='|').format('~@ cart|s') == '2 cart'
 
+def test_plural_fraction():
+    from fractions import Fraction
+
+    assert '{:# day/s}'.format(plural(Fraction(0,2))) == '0 days'
+    assert '{:# day/s}'.format(plural(Fraction(1,2))) == '1/2 days'
+    assert '{:# day/s}'.format(plural(Fraction(2,2))) == '1 day'
+    assert '{:# day/s}'.format(plural(Fraction(3,2))) == '3/2 days'
+    assert '{:# day/s}'.format(plural(Fraction(4,2))) == '2 days'
+    
 def test_full_stop():
     assert full_stop('hey now') == 'hey now.'
     assert full_stop('hey now.') == 'hey now.'


### PR DESCRIPTION
The `plural()` function happens to choke on instances of `fraction.Fraction`, because these objects are rendered with a slash separating the numerator from the denominator, and that slash is mistakenly interpreted as part of the format string.  The solution is just to hold off on substituting the number into the format string until after everything else has been interpreted.