### PR TITLE
Defer evaluation of stdout and stderr.

### DIFF
--- a/inform/inform.py
+++ b/inform/inform.py
@@ -2089,8 +2089,8 @@ class Inform:
         self.termination_callback = termination_callback
         self.error_status = error_status
         self.flush = flush
-        self.stdout = stdout if stdout else sys.stdout
-        self.stderr = stderr if stderr else sys.stderr
+        self._stdout = stdout
+        self._stderr = stderr
         self.__dict__.update(kwargs)
         self.previous_action = None
         self.logfile = None
@@ -2146,6 +2146,16 @@ class Inform:
         if name.startswith('__'):
             raise AttributeError(name)
         return self.__dict__.get(name)
+
+    # stdout {{{2
+    @property
+    def stdout(self):
+        return self._stdout or sys.stdout
+
+    # stderr {{{2
+    @property
+    def stderr(self):
+        return self._stderr or sys.stderr
 
     # suppress_output {{{2
     def suppress_output(self, mute=True):

--- a/tests/test_inform.py
+++ b/tests/test_inform.py
@@ -751,6 +751,21 @@ def test_stripy():
             {expected}
         ''').strip().format(expected=expected)
 
+def test_capsys_out(capsys):
+    output('hello world')
+    cap = capsys.readouterr()
+    assert cap.out == 'hello world\n'
+
+def test_capsys_err(capsys):
+    try:
+        fatal('goodbye world')
+    except SystemExit:
+        pass
+    cap = capsys.readouterr()
+    assert 'goodbye world' in cap.err
+
+
+    
 
 if __name__ == '__main__':
     # As a debugging aid allow the tests to be run on their own, outside pytest.


### PR DESCRIPTION
Saving references to `sys.stdout` and `sys.stderr` at import-time makes it hard to unit test the output generated by informants (e.g. using the `capsys` pytest fixture).